### PR TITLE
Moved Cheque Value to Lore.

### DIFF
--- a/src/main/java/com/vnator/adminshop/packets/PacketWithdrawMoney.java
+++ b/src/main/java/com/vnator/adminshop/packets/PacketWithdrawMoney.java
@@ -58,9 +58,9 @@ public class PacketWithdrawMoney implements IMessage{
 
 			tag.setFloat("value", message.money);
 			tag.setTag("display", displayTag);
-			displayTag.setTag("Name", new NBTTagString("Check $"+message.money));
+			displayTag.setTag("Name", new NBTTagString("Banker's Check"));
 			displayTag.setTag("Lore", loreTag);
-			loreTag.appendTag(new NBTTagString("From: "+player.getName()));
+			loreTag.appendTag(new NBTTagString("Value: $"+message.money));
 
 			ItemStack check = new ItemStack(Item.getByNameOrId("adminshop:check"), 1, 0);
 


### PR DESCRIPTION
In order to assure checks have same meta data as others withdrawn from ATMs to allow use with Villager Trading. Also moving Value to lore preventing people from renaming checks to a higher value.